### PR TITLE
Add visualization project to TOOLS page

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -224,6 +224,18 @@
                         | (<a href="http://www.ros.org/wiki/mjpegcanvasjs/Tutorials">Tutorials</a>)</p>
                       </section>
                     </div>
+                    <div class="4u">
+                      <section>
+                        <a href="https://github.com/tork-a/vizualization_rwt"><span class="image image-full">
+                        <img src="http://wiki.ros.org/rtmros_nextage?action=AttachFile&do=get&target=nxo_rwt_moveit_1.png" /></span>
+                        <h3>vizualization_rwt</h3></a> 
+                        <span class="byline">RWT-based utility widget suite for interacting ROS-based robots</span>
+                        <p>CDN: (N/A yet) | Doc: (N/A yet) | Source: (<a href="https://github.com/tork-a/vizualization_rwt">GitHub</a>)
+                        <br />
+                        Wiki: (<a href="http://wiki.ros.org/vizualization_rwt/">ROS Wiki</a>)
+                        | (Tutorials N/A yet)</p>
+                      </section>
+                    </div>
                   </div>
                   
                   <br /> <br /> <br />


### PR DESCRIPTION
I'd like to contribute to [`tools` section of RWT web site](http://robotwebtools.org/tools.html) by adding our visualization packages.

Some N/As...
- Distribution method is not well discussed yet.
- Documentation is generated on ros wiki per package but I just don't know how I can add it in this aggregated form, so I kept it blank.

CC @garaemon @k-okada