### PR TITLE
Updated mjpeg_server to web_video_server

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -7,7 +7,7 @@
   type="text/css" />
 <script src="js/jquery-1.8.3.min.js"></script>
 <script src="css/5grid/init.js?use=mobile,desktop,1000px&amp;mobileUI=1&amp;mobileUI.theme=none">
-  
+
 </script>
 <script src="js/jquery.dropotron-1.2.js"></script>
 <script src="js/init.js"></script>
@@ -117,9 +117,9 @@
                       <section>
                         <a href="https://github.com/RobotWebTools/roslibjs"><span class="image image-full">
                         <img src="images/demos/roslibjs-code.jpg" /></span>
-                        <h3>roslibjs</h3></a> 
+                        <h3>roslibjs</h3></a>
                         <span class="byline">The Standard ROS JavaScript Library</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/roslibjs/current/roslib.min.js">min</a>) 
+                        <p>CDN: (<a href="http://cdn.robotwebtools.org/roslibjs/current/roslib.min.js">min</a>)
                         | (<a href="http://cdn.robotwebtools.org/roslibjs/current/roslib.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/roslibjs/current/">JSDoc</a>)
@@ -136,7 +136,7 @@
                         <img src="images/demos/ros2djs-map.jpg" /></span>
                         <h3>ros2djs</h3></a>
                         <span class="byline">2D Visualization Library for use with the ROS JavaScript Libraries</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/ros2djs/current/ros2d.min.js">min</a>) 
+                        <p>CDN: (<a href="http://cdn.robotwebtools.org/ros2djs/current/ros2d.min.js">min</a>)
                         | (<a href="http://cdn.robotwebtools.org/ros2djs/current/ros2d.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/ros2djs/current/">JSDoc</a>)
@@ -151,9 +151,9 @@
                       <section>
                         <a href="https://github.com/RobotWebTools/ros3djs"><span class="image image-full">
                         <img src="images/demos/ros3djs-pr2-urdf.jpg" /></span>
-                        <h3>ros3djs</h3></a> 
+                        <h3>ros3djs</h3></a>
                         <span class="byline">3D Visualization Library for use with the ROS JavaScript Libraries</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/ros3djs/current/ros3d.min.js">min</a>) 
+                        <p>CDN: (<a href="http://cdn.robotwebtools.org/ros3djs/current/ros3d.min.js">min</a>)
                         | (<a href="http://cdn.robotwebtools.org/ros3djs/current/ros3d.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/ros3djs/current/">JSDoc</a>)
@@ -177,9 +177,9 @@
                       <section>
                         <a href="https://github.com/WPI-RAIL/nav2djs"><span class="image image-full">
                         <img src="images/demos/nav2djs-example.jpg" /></span>
-                        <h3>nav2djs</h3></a> 
+                        <h3>nav2djs</h3></a>
                         <span class="byline">2D Navigation Widget </span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/nav2djs/current/nav2d.min.js">min</a>) 
+                        <p>CDN: (<a href="http://cdn.robotwebtools.org/nav2djs/current/nav2d.min.js">min</a>)
                         | (<a href="http://cdn.robotwebtools.org/nav2djs/current/nav2d.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/nav2djs/current/">JSDoc</a>)
@@ -196,7 +196,7 @@
                         <img src="images/demos/keyboardteleopjs-keys.jpg" /></span>
                         <h3>keyboardteleopjs</h3></a>
                         <span class="byline">Keyboard Teleoperation via Twist Messages </span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/keyboardteleopjs/current/keyboardteleop.min.js">min</a>) 
+                        <p>CDN: (<a href="http://cdn.robotwebtools.org/keyboardteleopjs/current/keyboardteleop.min.js">min</a>)
                         | (<a href="http://cdn.robotwebtools.org/keyboardteleopjs/current/keyboardteleop.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/keyboardteleopjs/current/">JSDoc</a>)
@@ -211,9 +211,9 @@
                       <section>
                         <a href="https://github.com/WPI-RAIL/mjpegcanvasjs"><span class="image image-full">
                         <img src="images/demos/mjpegcanvasjs-example.jpg" /></span>
-                        <h3>mjpegcanvasjs</h3></a> 
+                        <h3>mjpegcanvasjs</h3></a>
                         <span class="byline">Display a MJPEG stream from the ROS mjpeg_server Inside of a HTML5 Canvas</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/mjpegcanvasjs/current/mjpegcanvas.min.js">min</a>) 
+                        <p>CDN: (<a href="http://cdn.robotwebtools.org/mjpegcanvasjs/current/mjpegcanvas.min.js">min</a>)
                         | (<a href="http://cdn.robotwebtools.org/mjpegcanvasjs/current/mjpegcanvas.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/mjpegcanvasjs/current/">JSDoc</a>)
@@ -228,7 +228,7 @@
                       <section>
                         <a href="https://github.com/tork-a/visualization_rwt"><span class="image image-full">
                         <img src="images/demos/nxo_rwt_moveit_1.png" /></span>
-                        <h3>visualization_rwt</h3></a> 
+                        <h3>visualization_rwt</h3></a>
                         <span class="byline">RWT-based utility widget suite for interacting ROS-based robots</span>
                         <p>CDN: (N/A yet) | Doc: (N/A yet) | Source: (<a href="https://github.com/tork-a/visualization_rwt">GitHub</a>)
                         <br />
@@ -240,9 +240,9 @@
                       <section>
                         <a href="https://github.com/DLu/joint_state_publisher_js"><span class="image image-full">
                         <img src="images/demos/jsp.png" /></span>
-                        <h3>joint_state_publisher_js</h3></a> 
+                        <h3>joint_state_publisher_js</h3></a>
                         <span class="byline">Visualize a URDF and manipulate its joints without running simulations.</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/joint_state_publisher_js/current/jointstatepublisher.min.js">min</a>) 
+                        <p>CDN: (<a href="http://cdn.robotwebtools.org/joint_state_publisher_js/current/jointstatepublisher.min.js">min</a>)
                         | (<a href="http://cdn.robotwebtools.org/joint_state_publisher_js/current/jointstatepublisher.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/mjpegcanvasjs/current/">JSDoc</a>)
@@ -254,23 +254,23 @@
                       </section>
                     </div>
                   </div>
-                  
+
                   <br /> <br /> <br />
 
                   <header class="major">
                     <h3 name="systems" id="systems">Systems</h3>
                   </header>
-                  
+
                   <div class="row">
                     <div class="4u">
                       <section>
                         <a href="https://github.com/WPI-RAIL/rms"><span class="image image-full">
                         <img src="images/demos/rms-homepage.jpg" /></span>
-                        <h3>rms</h3></a> 
+                        <h3>rms</h3></a>
                         <span class="byline">RMS (Robot Management System)</span>
                         <p>
                         Doc: (<a href="http://robotwebtools.org/jsdoc/rms/current/">JSDoc</a>)
-                        | (<a href="http://robotwebtools.org/phpdoc/rms/current/">PHPDoc</a>) 
+                        | (<a href="http://robotwebtools.org/phpdoc/rms/current/">PHPDoc</a>)
                         | (<a href="http://www.ros.org/wiki/rms/rest">REST</a>)
                         <br />
                         Source: (<a href="https://github.com/WPI-RAIL/rms">GitHub</a>)
@@ -292,7 +292,7 @@
                       <section>
                         <a href="https://github.com/RobotWebTools/rosbridge_suite"><span class="image image-full">
                         <img src="images/demos/rosbridge-logo.jpg" /></span>
-                        <h3>rosbridge_suite</h3></a> 
+                        <h3>rosbridge_suite</h3></a>
                         <span class="byline">Rosbridge 2.0 Server</span>
                         <p>Source: (<a href="https://github.com/RobotWebTools/rosbridge_suite">GitHub</a>)
                         <br />
@@ -301,20 +301,20 @@
                     </div>
                     <div class="4u">
                       <section>
-                        <a href="https://github.com/RobotWebTools/mjpeg_server"><span class="image image-full">
+                        <a href="https://github.com/RobotWebTools/web_video_server"><span class="image image-full">
                         <img src="images/demos/mjpegcanvasjs-example.jpg" /></span>
-                        <h3>mjpeg_server</h3></a>
-                        <span class="byline">A MJPEG Server Which is Able to Subscribe to any ROS Image Stream.</span>
-                        <p>Source: (<a href="https://github.com/RobotWebTools/mjpeg_server">GitHub</a>)
+                        <h3>web_video_server</h3></a>
+                        <span class="byline">Streaming of ROS Image Topics in Multiple Formats.</span>
+                        <p>Source: (<a href="https://github.com/RobotWebTools/web_video_server">GitHub</a>)
                         <br />
-                        Wiki: (<a href="http://www.ros.org/wiki/mjpeg_server/">ROS Wiki</a>)</p>
+                        Wiki: (<a href="http://wiki.ros.org/web_video_server">ROS Wiki</a>)</p>
                       </section>
                     </div>
                     <div class="4u">
                       <section>
                         <a href="https://github.com/RobotWebTools/tf2_web_republisher"><span class="image image-full">
                         <img src="images/demos/tf2-example.jpg" /></span>
-                        <h3>tf2_web_republisher</h3></a> 
+                        <h3>tf2_web_republisher</h3></a>
                         <span class="byline">Republishing of Selected TF Transforms</span>
                         <p>Source: (<a href="https://github.com/RobotWebTools/tf2_web_republisher">GitHub</a>)
                         <br />


### PR DESCRIPTION
Since mjpeg_server is deprecated and replaced by web_video_server, this change should be implemented on the website as well.