### PR TITLE
http://cdn to https://static

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -112,8 +112,8 @@
                         <img src="images/demos/roslibjs-code.jpg" /></span>
                         <h3>roslibjs</h3></a>
                         <span class="byline">The Standard ROS JavaScript Library</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/roslibjs/current/roslib.min.js">min</a>)
-                        | (<a href="http://cdn.robotwebtools.org/roslibjs/current/roslib.js">full</a>)
+                        <p>CDN: (<a href="https://static.robotwebtools.org/roslibjs/current/roslib.min.js">min</a>)
+                        | (<a href="https://static.robotwebtools.org/roslibjs/current/roslib.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/roslibjs/current/">JSDoc</a>)
                         <br />
@@ -129,8 +129,8 @@
                         <img src="images/demos/ros2djs-map.jpg" /></span>
                         <h3>ros2djs</h3></a>
                         <span class="byline">2D Visualization Library for use with the ROS JavaScript Libraries</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/ros2djs/current/ros2d.min.js">min</a>)
-                        | (<a href="http://cdn.robotwebtools.org/ros2djs/current/ros2d.js">full</a>)
+                        <p>CDN: (<a href="https://static.robotwebtools.org/ros2djs/current/ros2d.min.js">min</a>)
+                        | (<a href="https://static.robotwebtools.org/ros2djs/current/ros2d.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/ros2djs/current/">JSDoc</a>)
                         <br />
@@ -146,8 +146,8 @@
                         <img src="images/demos/ros3djs-fetch-urdf.jpg" /></span>
                         <h3>ros3djs</h3></a>
                         <span class="byline">3D Visualization Library for use with the ROS JavaScript Libraries</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/ros3djs/current/ros3d.min.js">min</a>)
-                        | (<a href="http://cdn.robotwebtools.org/ros3djs/current/ros3d.js">full</a>)
+                        <p>CDN: (<a href="https://static.robotwebtools.org/ros3djs/current/ros3d.min.js">min</a>)
+                        | (<a href="https://static.robotwebtools.org/ros3djs/current/ros3d.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/ros3djs/current/">JSDoc</a>)
                         <br />
@@ -219,8 +219,8 @@
                         <img src="images/demos/nav2djs-example.jpg" /></span>
                         <h3>nav2djs</h3></a>
                         <span class="byline">2D Navigation Widget </span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/nav2djs/current/nav2d.min.js">min</a>)
-                        | (<a href="http://cdn.robotwebtools.org/nav2djs/current/nav2d.js">full</a>)
+                        <p>CDN: (<a href="https://static.robotwebtools.org/nav2djs/current/nav2d.min.js">min</a>)
+                        | (<a href="https://static.robotwebtools.org/nav2djs/current/nav2d.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/nav2djs/current/">JSDoc</a>)
                         <br />
@@ -236,8 +236,8 @@
                         <img src="images/demos/keyboardteleopjs-keys.jpg" /></span>
                         <h3>keyboardteleopjs</h3></a>
                         <span class="byline">Keyboard Teleoperation via Twist Messages </span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/keyboardteleopjs/current/keyboardteleop.min.js">min</a>)
-                        | (<a href="http://cdn.robotwebtools.org/keyboardteleopjs/current/keyboardteleop.js">full</a>)
+                        <p>CDN: (<a href="https://static.robotwebtools.org/keyboardteleopjs/current/keyboardteleop.min.js">min</a>)
+                        | (<a href="https://static.robotwebtools.org/keyboardteleopjs/current/keyboardteleop.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/keyboardteleopjs/current/">JSDoc</a>)
                         <br />
@@ -253,8 +253,8 @@
                         <img src="images/demos/mjpegcanvasjs-example.jpg" /></span>
                         <h3>mjpegcanvasjs</h3></a>
                         <span class="byline">Display a MJPEG stream from the ROS mjpeg_server Inside of a HTML5 Canvas</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/mjpegcanvasjs/current/mjpegcanvas.min.js">min</a>)
-                        | (<a href="http://cdn.robotwebtools.org/mjpegcanvasjs/current/mjpegcanvas.js">full</a>)
+                        <p>CDN: (<a href="https://static.robotwebtools.org/mjpegcanvasjs/current/mjpegcanvas.min.js">min</a>)
+                        | (<a href="https://static.robotwebtools.org/mjpegcanvasjs/current/mjpegcanvas.js">full</a>)
                         <br />
                         Doc: (<a href="http://robotwebtools.org/jsdoc/mjpegcanvasjs/current/">JSDoc</a>)
                         <br />
@@ -282,8 +282,8 @@
                         <img src="images/demos/jsp.png" /></span>
                         <h3>Joint State Publisher</h3></a>
                         <span class="byline">Visualize a URDF and manipulate its joints without running simulations.</span>
-                        <p>CDN: (<a href="http://cdn.robotwebtools.org/jointstatepublisherjs/current/jointstatepublisher.min.js">min</a>)
-                        | (<a href="http://cdn.robotwebtools.org/jointstatepublisherjs/current/jointstatepublisher.js">full</a>)
+                        <p>CDN: (<a href="https://static.robotwebtools.org/jointstatepublisherjs/current/jointstatepublisher.min.js">min</a>)
+                        | (<a href="https://static.robotwebtools.org/jointstatepublisherjs/current/jointstatepublisher.js">full</a>)
                         <br />
                         Source: (<a href="https://github.com/DLu/joint_state_publisher_js">GitHub</a>)
                         <br />


### PR DESCRIPTION

Note that keyboardteleopjs and joint state publisher tools are not in cdn.